### PR TITLE
Definitions with arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    siringa (0.0.5)
+    siringa (0.0.6)
 
 GEM
   remote: http://rubygems.org/

--- a/app/controllers/siringa/siringa_controller.rb
+++ b/app/controllers/siringa/siringa_controller.rb
@@ -2,7 +2,7 @@ module Siringa
   class SiringaController < ApplicationController
 
     def load
-      Siringa.load_definition(params['definition'].to_sym)
+      Siringa.load_definition(params['definition'].to_sym, options)
       resp = { :text => "Definition #{params['definition']} loaded.", :status => :created }
     rescue ArgumentError => exception
       resp = { :text => exception.to_s, :status => :method_not_allowed }
@@ -45,5 +45,13 @@ module Siringa
       render resp
     end
 
+    private
+
+    # Returns the arguments to be passed to the definition
+    #
+    # @return [Hash] arguments of the definition
+    def options
+      params[:siringa_args]
+    end
   end
 end

--- a/lib/siringa/definitions.rb
+++ b/lib/siringa/definitions.rb
@@ -8,9 +8,10 @@ module Siringa
   # Load a definition and run its code
   #
   # @param [Symbol] name of the definition
-  def self.load_definition(name)
+  # @param [Hash] arguments of the definition
+  def self.load_definition(name, options)
     if exists_definition?(name)
-      @definitions[name].call
+      @definitions[name].call(options)
     else
       raise ArgumentError, "Definition #{name.to_s} does not exist.", caller
     end

--- a/lib/siringa/version.rb
+++ b/lib/siringa/version.rb
@@ -1,3 +1,3 @@
 module Siringa
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/siringa.gemspec
+++ b/siringa.gemspec
@@ -7,8 +7,8 @@ require "siringa/version"
 Gem::Specification.new do |s|
   s.name        = "siringa"
   s.version     = Siringa::VERSION
-  s.authors     = ["Enrico Stano"]
-  s.email       = ["enricostn@gmail.com"]
+  s.authors     = ["Enrico Stano", "Pau Pérez"]
+  s.email       = ["enricostn@gmail.com", "saulopefa@gmail.com"]
   s.homepage    = "https://github.com/enricostano/siringa"
   s.summary     = "Remotely populate DB for Rails applications for pure client acceptance testing"
   s.description = "Remotely populate DB for Rails applications for pure client acceptance testing"

--- a/test/controllers/siringa_controller_test.rb
+++ b/test/controllers/siringa_controller_test.rb
@@ -20,4 +20,9 @@ class SiringaControllerTest < ActionController::TestCase
     assert_response :method_not_allowed
   end
 
+  test "load action passing arguments" do
+    get :load, { definition: "definition_with_arguments", siringa_args: { name: 'Robb Stark' }, use_route: "siringa" }
+    assert_response :success
+  end
+
 end

--- a/test/dummy/test/siringa/definitions.rb
+++ b/test/dummy/test/siringa/definitions.rb
@@ -4,3 +4,7 @@ require File.expand_path('../../factories', __FILE__)
 Siringa.add_definition :initial do
   FactoryGirl.create :user, name: 'Jesse Pinkman'
 end
+
+Siringa.add_definition :definition_with_arguments do |args|
+  FactoryGirl.create :user, name: args[:name]
+end


### PR DESCRIPTION
This aims to add support for arguments in definitions, so that you can customize your definitions depending on your needs.

Thus, with this you can add arguments to your definition as:

```ruby
Siringa.add_definition :create_user do |args|
   user = User.create(name: args[:name], email: args[:email])
   user.invite_to_project(args[:project_id])
end
```

For this to work, you will need to provide all needed arguments through the request you issue to your definition. All arguments must be specified under the key `siringa_args` in the JSON you provide.

So, the request below would run the `create_user` definition successfully:

```bash
curl -X POST 'http://localhost:3000/siringa/load/dummy' -H "Content-Type: application/json" -d '{"siringa_args": {"name": "Jorge Stano", "email": "jorge@gmail.com", "project_id": 2}}'
```