### PR TITLE
Return JSON in responses to allow clients gather the inserted data

### DIFF
--- a/app/controllers/siringa/siringa_controller.rb
+++ b/app/controllers/siringa/siringa_controller.rb
@@ -2,14 +2,12 @@ module Siringa
   class SiringaController < ApplicationController
 
     def load
-      Siringa.load_definition(params['definition'].to_sym, options)
-      resp = { :text => "Definition #{params['definition']} loaded.", :status => :created }
+      result = Siringa.load_definition(params['definition'].to_sym, options)
+      render json: result, status: :created
     rescue ArgumentError => exception
-      resp = { :text => exception.to_s, :status => :method_not_allowed }
-    rescue => exception
-      resp = { :text => exception.to_s, :status => :internal_server_error }
-    ensure
-      render resp
+      render json: { error: exception.to_s }, status: :method_not_allowed
+    rescue StandardError => exception
+      render json: { error: exception.to_s }, status: :internal_server_error
     end
 
     def dump

--- a/test/controllers/siringa_controller_test.rb
+++ b/test/controllers/siringa_controller_test.rb
@@ -21,8 +21,22 @@ class SiringaControllerTest < ActionController::TestCase
   end
 
   test "load action passing arguments" do
-    get :load, { definition: "definition_with_arguments", siringa_args: { name: 'Robb Stark' }, use_route: "siringa" }
+    get :load, {
+      definition: "definition_with_arguments",
+      siringa_args: { name: 'Robb Stark' },
+      use_route: "siringa"
+    }
     assert_response :success
   end
 
+  test "load action returning JSON response" do
+    get :load, {
+      definition: "definition_with_return",
+      siringa_args: { name: 'Ned' },
+      use_route: "siringa"
+    }
+    assert body['id']
+    assert_equal 'Ned', body['name']
+    assert_equal 'Stark', body['surname']
+  end
 end

--- a/test/dummy/test/siringa/definitions.rb
+++ b/test/dummy/test/siringa/definitions.rb
@@ -8,3 +8,8 @@ end
 Siringa.add_definition :definition_with_arguments do |args|
   FactoryGirl.create :user, name: args[:name]
 end
+
+Siringa.add_definition :definition_with_return do |args|
+  user = FactoryGirl.create :user, name: args[:name]
+  { id: user.id, name: user.name, surname: 'Stark' }
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,8 @@ Rails.backtrace_cleaner.remove_silencers!
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
+# Parse JSON response body
+def body
+  JSON.parse(@response.body)
+end


### PR DESCRIPTION
In order for Siringa to be really useful, I was missing some way to get the created data back. This returns Siringa definition's result as a JSON in the response.

It does also return the exception messages for unsuccessful requests within a JSON, as if it was a REST api.

Thus, you can whatever you need as the return value of the block, and it'll be included in the response as JSON.

```ruby
Siringa.add_definition :create_user do |args|
   user = User.create(name: args[:name], email: args[:email])
   user.invite_to_project(args[:project_id])
   user.attributes
end
```

For instance, the definition above will return the attributes of the user it just created.