### PR TITLE
Change reserved method name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    siringa (0.0.6)
+    siringa (0.0.7)
 
 GEM
   remote: http://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -72,24 +72,24 @@ Now that we've created our definitions we could use them in our two cases:
 ### As seed data
 You could just load the `initial` definition running the following rake recipe after your deploy:
 ```console
-rake siringa:load
+rake siringa:load_definition
 ```
 `initial` is the default definition this Rake task recipe will try to load, if you want to load another definition instead you could pass its name as argument:
 ```console
-rake 'siringa:load[another_definition]'
+rake 'siringa:load_definition[another_definition]'
 ```
 This will load a definition named `:another_definition`. Please note that if you use Zsh shell you'll need to use quotes, more info [here](http://robots.thoughtbot.com/post/18129303042/how-to-use-arguments-in-a-rake-task).
 
 If you want to force a Rails environment you could just run the Sriringa recipe specifing the `RAILS_ENV` environmental variable:
 ```console
-RAILS_ENV=development rake siringa:load
+RAILS_ENV=development rake siringa:load_definition
 ```
 
 ### During an acceptance test
 As you can see running `rake routes`, Siringa added 3 new routes to your API:
 ```console
 Routes for Siringa::Engine:
-        POST /load/:definition(.:format) siringa/siringa#load
+        POST /load_definition/:definition(.:format) siringa/siringa#load_definition
    dump POST /dump(.:format)             siringa/siringa#dump
 restore POST /restore(.:format)          siringa/siringa#restore
 ```
@@ -100,7 +100,7 @@ The workflow I propose here is:
 
    This will create a `.dump` file in the `tmp/dumps` directory created during the install process. You could create as many dump files as you want but Siringa will keep only the latest 5 dumps created.
 
-2. Load a Siringa definition performing a `POST` request to `YOURHOST/siringa/load/specific`
+2. Load a Siringa definition performing a `POST` request to `YOURHOST/siringa/load_definition/specific`
 
    This will run the code defined in a definition named `specific` on the server.
 
@@ -126,7 +126,7 @@ end
 ## Acceptance test example
 Just to get the idea, the following script will show you how to use Siringa in a acceptance test using Selenium, [rest-client](https://github.com/rest-client/rest-client) and RSpec:
 ```ruby
-require 'selenium-webdriver'dd
+require 'selenium-webdriver'
 require 'rspec'
 require 'rest_client'
 
@@ -144,9 +144,9 @@ describe "Acceptance test using Siringa" do
     @driver.quit
   end
 
-  it "Load a definition and test something" do
-    # Load a definition named 'specific'
-    RestClient.post 'YOURHOST/siringa/load', { :definition => :specific }
+  it "Loads a definition and test something" do
+    # Loads a definition named 'specific'
+    RestClient.post 'YOURHOST/siringa/load_definition', { definition: :specific }
 
     # Here goes your test
 
@@ -163,5 +163,5 @@ end
 ## How to collaborate
 * Fork the repo and send a pull request, thanks!
 
-# Licence
+# License
 MIT-LICENSE 2013 Enrico Stano

--- a/app/controllers/siringa/siringa_controller.rb
+++ b/app/controllers/siringa/siringa_controller.rb
@@ -1,7 +1,7 @@
 module Siringa
   class SiringaController < ApplicationController
 
-    def load
+    def load_definition
       result = Siringa.load_definition(params['definition'].to_sym, options)
       render json: result, status: :created
     rescue ArgumentError => exception

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Siringa::Engine.routes.draw do
-  post "load/:definition", :to => "siringa#load"
+  post "load_definition/:definition", :to => "siringa#load_definition"
   post "dump", :to => "siringa#dump"
   post "restore", :to => "siringa#restore"
 end

--- a/lib/tasks/siringa_tasks.rake
+++ b/lib/tasks/siringa_tasks.rake
@@ -1,6 +1,6 @@
 namespace :siringa do
   desc "Load a definition and populate the DB with seed data"
-  task :load, [:definition] do |t, args|
+  task :load_definition, [:definition] do |t, args|
     args.with_defaults :definition => :initial
     Rake::Task["environment"].invoke
     puts <<-EOS

--- a/test/controllers/siringa_controller_test.rb
+++ b/test/controllers/siringa_controller_test.rb
@@ -10,18 +10,18 @@ class SiringaControllerTest < ActionController::TestCase
   def teardown
   end
 
-  test "load action passing existing factory" do
-    get :load, { definition: "initial", use_route: "siringa" }
+  test "load_definition action passing existing factory" do
+    get :load_definition, { definition: "initial", use_route: "siringa" }
     assert_response :success
   end
 
-  test "load action passing a factory that doesn't exist" do
-    get :load, { definition: "papapa", use_route: "siringa" }
+  test "load_definition action passing a factory that doesn't exist" do
+    get :load_definition, { definition: "papapa", use_route: "siringa" }
     assert_response :method_not_allowed
   end
 
-  test "load action passing arguments" do
-    get :load, {
+  test "load_definition action passing arguments" do
+    get :load_definition, {
       definition: "definition_with_arguments",
       siringa_args: { name: 'Robb Stark' },
       use_route: "siringa"
@@ -29,8 +29,8 @@ class SiringaControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "load action returning JSON response" do
-    get :load, {
+  test "load_definition action returning JSON response" do
+    get :load_definition, {
       definition: "definition_with_return",
       siringa_args: { name: 'Ned' },
       use_route: "siringa"


### PR DESCRIPTION
### WAT
It turns out that using `#load` as method name is not a good idea since it's a reserved word :tada: 

### GIF
![](http://media.giphy.com/media/290avtlx6LFII/giphy.gif)