### PR TITLE
Added deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Siringa :syringe:
 This gem was born working on pure client acceptance testing in [Teambox](http://www.teambox.com).
+## WARNING :warning:
+Due to a conflict with reserved word `load` we are deprecating `#load` action in `SiringaController` in favour of `#load_definition`. This change is reflected by a warning in logs but will be dropped in version `0.1.0`.
 ## The problem
 
 You have a Rails based API and you need to write some acceptance tests using your Javascript/iOS/Android/whatever client.

--- a/app/controllers/siringa/siringa_controller.rb
+++ b/app/controllers/siringa/siringa_controller.rb
@@ -1,6 +1,14 @@
 module Siringa
   class SiringaController < ApplicationController
 
+    # TODO: deprecate in 0.1.0
+    #
+    def load
+      Rails.logger.warn '[Siringa] Using /load route has been deprecated in favour of /load_definition. Will be dropped in 0.1.0'
+
+      load_definition
+    end
+
     def load_definition
       result = Siringa.load_definition(params['definition'].to_sym, options)
       render json: result, status: :created

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Siringa::Engine.routes.draw do
+  post "load/:definition", :to => "siringa#load" # To be deprecated in 0.1.0
   post "load_definition/:definition", :to => "siringa#load_definition"
   post "dump", :to => "siringa#dump"
   post "restore", :to => "siringa#restore"


### PR DESCRIPTION
Due to a conflict with reserved word `load` we are deprecating `#load` action in `SiringaController` in favour of `#load_definition`. This change is reflected by a warning in logs but will be dropped in version `0.1.0`